### PR TITLE
Set minimum Node.js version to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "snyk-github-issue-creator": "./cli/index.js"
     },
     "engines": {
-        "node": ">=10"
+        "node": ">=14"
     },
     "author": "pierre-ernst",
     "license": "ISC",


### PR DESCRIPTION
The current code uses syntax that requires Node.js 14 or newer. If we want to support older versions, I can change the code, but if not, let's just bump the requirement in `package.json`.