### PR TITLE
Remove unused UUID validation code

### DIFF
--- a/cli/config.js
+++ b/cli/config.js
@@ -4,7 +4,6 @@ const chalk = require('chalk');
 const fs = require('fs');
 const Configstore = require('configstore');
 const { prompt } = require('enquirer');
-const uuidValidate = require('uuid-validate');
 
 const { name: pkgName, version: pkgVersion } = require('../package.json');
 const Snyk = require('./snyk');
@@ -238,8 +237,4 @@ function list(value) {
     return typeof value === 'string'
         ? value.split(',').map((s) => s.trim())
         : value;
-}
-
-function uuid(value) {
-    return uuidValidate(value) ? true : 'Invalid UUID(s)';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1379,11 +1379,6 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
-        "uuid-validate": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/uuid-validate/-/uuid-validate-0.0.3.tgz",
-            "integrity": "sha512-Fykw5U4eZESbq739BeLvEBFRuJODfrlmjx5eJux7W817LjRaq4b7/i4t2zxQmhcX+fAj4nMfRdTzO4tmwLKn0w=="
-        },
         "verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
         "minimist": "^1.2.5",
         "request": "^2.88.0",
         "request-promise-native": "^1.0.9",
-        "semver": "^7.3.2",
-        "uuid-validate": "0.0.3"
+        "semver": "^7.3.2"
     },
     "devDependencies": {
         "prettier": "2.0.1",


### PR DESCRIPTION
This was left over from a previous refactoring.

The added complexity of validating the UUIDs with this library was too
large due to how the `enquirer` module works, so it was never properly
implemented.

There's really no added benefit of validating the UUIDs as the validator
only validates the UUID format, not that the UUIDs exists on the remote
server. If they do not exist, we'll know soon enough anyway.