### PR TITLE
Sort Snyk issues in CLI by priority score first to mimic web UI

### DIFF
--- a/cli/batch.js
+++ b/cli/batch.js
@@ -14,7 +14,7 @@ const {
 
 // Longest possible severity string. Each vulnerability in the prompt has a
 // severity label that is padded out to this many characters
-const SEVERITY_PREFIX_PADDING = 'Medium severity (999):'.length;
+const SEVERITY_PREFIX_PADDING = 'M|1000'.length;
 
 const getBatchProps = async (issues) => {
     const packageNames = uniq(issues.map((x) => x.package));
@@ -38,7 +38,7 @@ const getBatchProps = async (issues) => {
     const choices = Object.entries(reduced).map(([packageName, issues]) => {
         const severity = getBatchSeverityString(issues);
         const version = getBatchVersionString(issues);
-        return `${severity} ${packageName} ${version}`;
+        return `${severity} - ${packageName} ${version}`;
     });
 
     const { selected } = await prompt({
@@ -48,7 +48,7 @@ const getBatchProps = async (issues) => {
         choices,
     });
 
-    const trimmed = selected.slice(SEVERITY_PREFIX_PADDING + 1); // remove the severity prefix
+    const trimmed = selected.slice(SEVERITY_PREFIX_PADDING + ' - '.length); // remove the severity prefix
     const packageName = trimmed.substring(0, trimmed.indexOf(' '));
     const version = trimmed.substring(trimmed.indexOf(' ') + 1);
     const _issues = issues.filter((issue) => issue.package === packageName);
@@ -60,12 +60,10 @@ const getBatchProps = async (issues) => {
 };
 
 const getBatchSeverityString = (issues) => {
-    const severities = uniq(issues.map((x) => x.severity)).sort(
-        compare.severities
-    );
-    const severityText = `${capitalize(severities[0])} severity (${
-        issues[0].priorityScore
-    }):`; // only use the highest severity level (High, Medium, or Low)
+    // assume that the issues are already sorted in descending order of priority score
+    const severity = capitalize(issues[0].severity[0]); // only use the severity level of the highest-scored issue
+    const score = issues[0].priorityScore; // only use the priority score of the highest-scored issue
+    const severityText = `${severity}|${score}`;
     const padding = ' '
         .repeat(SEVERITY_PREFIX_PADDING)
         .slice(severityText.length);

--- a/cli/batch.js
+++ b/cli/batch.js
@@ -12,7 +12,9 @@ const {
     getGraph,
 } = require('./utils');
 
-const SEVERITY_PREFIX_PADDING = 16; // each vulnerability in the prompt has a severity label that is padded out to this many characters
+// Longest possible severity string. Each vulnerability in the prompt has a
+// severity label that is padded out to this many characters
+const SEVERITY_PREFIX_PADDING = 'Medium severity (999):'.length;
 
 const getBatchProps = async (issues) => {
     const packageNames = uniq(issues.map((x) => x.package));
@@ -61,7 +63,9 @@ const getBatchSeverityString = (issues) => {
     const severities = uniq(issues.map((x) => x.severity)).sort(
         compare.severities
     );
-    const severityText = `${capitalize(severities[0])} severity:`; // only use the highest severity level (High, Medium, or Low)
+    const severityText = `${capitalize(severities[0])} severity (${
+        issues[0].priorityScore
+    }):`; // only use the highest severity level (High, Medium, or Low)
     const padding = ' '
         .repeat(SEVERITY_PREFIX_PADDING)
         .slice(severityText.length);

--- a/cli/index.js
+++ b/cli/index.js
@@ -96,6 +96,7 @@ async function createIssues() {
 
     let issues = flatten(projectIssues).sort(
         (a, b) =>
+            b.priorityScore - a.priorityScore || // descending priority score
             compare.severities(a.severity, b.severity) || // descending severity (High, then Medium, then Low)
             compare.text(a.package, b.package) || // ascending package name
             compare.versions(a.version, b.version) || // descending package version

--- a/cli/index.js
+++ b/cli/index.js
@@ -11,7 +11,13 @@ const flatten = require('lodash.flatten');
 const { getBatchProps, getBatchIssue } = require('./batch');
 const { init: initConfig, conf } = require('./config');
 const { getLabels, ensureLabelsAreCreated } = require('./labels');
-const { compare, getProjectName, getGraph, uniq } = require('./utils');
+const {
+    capitalize,
+    compare,
+    getProjectName,
+    getGraph,
+    uniq,
+} = require('./utils');
 const Snyk = require('./snyk');
 
 let octokit;
@@ -168,19 +174,28 @@ async function createIssues() {
     const issueQuestions = [];
 
     let ctr = 0;
-    console.log(`Found ${issues.length} vulnerabilities:\n`);
+    console.log(`Found ${issues.length} vulnerabilities...`);
+    console.log(
+        `Format: [Severity]|[Priority score] - [Package name] [Package Version] - [Vuln title] - [Vuln ID]\n`
+    );
     issues.forEach((issue, i) => {
-        const description = `${i + 1}. ${issue.package} ${issue.version} - ${
-            issue.title
-        }`;
-        console.log(`${description} - ${issue.id} (${issue.severity})
-${getGraph(issue, ' * ', true)}
-`);
+        const {
+            severity,
+            priorityScore,
+            package: pkg,
+            version,
+            title,
+            id,
+        } = issue;
+        const severityPrefix = `${capitalize(severity[0])}|${priorityScore}`;
+        const num = i + 1;
+        const description = `${num}. ${severityPrefix} - ${pkg} ${version} - ${title} - ${id}`;
+        console.log(`${description}\n${getGraph(issue, ' * ', true)}\n`);
         issueQuestions.push({
             type: 'confirm',
             name: `question-${ctr++}`,
             message: conf.batch
-                ? `Add ${description} to batch?`
+                ? `Add "${description}" to batch?`
                 : `Create GitHub issue for ${description}?`,
             default: false,
         });


### PR DESCRIPTION
Example of new output - notice that high and medium are now mixed and instead sorted first by the priority score which is shown in parentheses):
 
![image](https://user-images.githubusercontent.com/5295965/109712606-3a51f200-7b6e-11eb-871b-0ab9e2adf6f8.png)

...

![image](https://user-images.githubusercontent.com/5295965/109712485-168eac00-7b6e-11eb-8cbd-7f4533b17186.png)
