### PR TITLE
Support inactive and deleted projects in the CLI prompt

### DIFF
--- a/cli/snyk.js
+++ b/cli/snyk.js
@@ -28,14 +28,27 @@ module.exports = class Snyk {
         ).orgs;
     }
 
-    async projects(orgId) {
-        return (
+    async projects(orgId, selectedProjects) {
+        const projects = (
             await request({
                 url: `${baseUrl}/org/${orgId || this._orgId}/projects`,
                 headers: this._headers,
                 json: true,
             })
         ).projects;
+        return projects
+            .map((project) => {
+                const { issueCountsBySeverity } = project;
+                const { high, medium, low } = issueCountsBySeverity;
+                const issueCountTotal = high + medium + low;
+                return { ...project, issueCountTotal };
+            })
+            .filter(({ id, isMonitored, issueCountTotal }) => {
+                if (selectedProjects.includes(id)) {
+                    return true;
+                }
+                return isMonitored;
+            });
     }
 
     async issues(projectId) {

--- a/cli/snyk.js
+++ b/cli/snyk.js
@@ -29,13 +29,11 @@ module.exports = class Snyk {
     }
 
     async projects(orgId, selectedProjects = []) {
-        const projects = (
-            await request({
-                url: `${baseUrl}/org/${orgId || this._orgId}/projects`,
-                headers: this._headers,
-                json: true,
-            })
-        ).projects;
+        const { projects } = await request({
+            url: `${baseUrl}/org/${orgId || this._orgId}/projects`,
+            headers: this._headers,
+            json: true,
+        });
         return projects
             .map((project) => {
                 const { issueCountsBySeverity } = project;

--- a/cli/snyk.js
+++ b/cli/snyk.js
@@ -28,7 +28,7 @@ module.exports = class Snyk {
         ).orgs;
     }
 
-    async projects(orgId, selectedProjects) {
+    async projects(orgId, selectedProjects = []) {
         const projects = (
             await request({
                 url: `${baseUrl}/org/${orgId || this._orgId}/projects`,


### PR DESCRIPTION
Currently, the CLI prompt does not differentiate between active and inactive Snyk projects. In contrast, the Snyk web UI hides inactive projects by default.

Additionally, the CLI prompt will throw an error if a previously-selected project does not exist in the Snyk API response (this could happen if a project was deleted, for example).

This PR improves the CLI prompt in a few ways:
1. For active projects, it displays a `(# issues)` suffix in the CLI prompt
2. For inactive projects, it displays an `[Inactive project]` prefix in the CLI prompt
3. In the CLI prompt, it sorts projects to display inactive ones last
4. In the CLI prompt, it hides projects that A. are inactive AND B. were not previously selected in a saved config
