### PR TITLE
Add support for new API

### DIFF
--- a/cli/batch.js
+++ b/cli/batch.js
@@ -120,8 +120,8 @@ const getBatchIssue = async (issues) => {
 ## Detailed paths
 ${getGraph(issue, '* ', showFullManifest)}
 
-${issue.description}
-- [${issue.id}](${issue.url})
+${issue.issueData.description}
+- [${issue.id}](${issue.issueData.url})
 </details>`
                 )
                 .join('');

--- a/cli/batch.js
+++ b/cli/batch.js
@@ -9,7 +9,6 @@ const {
     uniq,
     getProjectName,
     getUniqueProjectNamePrefixes,
-    getGraph,
 } = require('./utils');
 
 // Longest possible severity string. Each vulnerability in the prompt has a
@@ -119,9 +118,6 @@ const getBatchIssue = async (issues) => {
 <summary>${i + 1}. ${issue.title} in ${issue.package} ${issue.version} (${
                             issue.id
                         })</summary>
-
-## Detailed paths
-${getGraph(issue, '* ', showFullManifest)}
 
 ${issue.description}
 - [${issue.id}](${issue.url})

--- a/cli/batch.js
+++ b/cli/batch.js
@@ -9,6 +9,7 @@ const {
     uniq,
     getProjectName,
     getUniqueProjectNamePrefixes,
+    getGraph,
 } = require('./utils');
 
 // Longest possible severity string. Each vulnerability in the prompt has a
@@ -16,28 +17,28 @@ const {
 const SEVERITY_PREFIX_PADDING = 'M|1000'.length;
 
 const getBatchProps = async (issues) => {
-    const packageNames = uniq(issues.map((x) => x.package));
+    const pkgNames = uniq(issues.map((x) => x.pkgName));
 
-    if (packageNames.length === 1) {
+    if (pkgNames.length === 1) {
         return {
-            packageName: packageNames[0],
+            pkgName: pkgNames[0],
             version: getBatchVersionString(issues),
             issues,
         };
     }
 
     const reduced = issues.reduce((acc, cur) => {
-        const packageName = cur.package;
-        if (!acc[packageName]) {
-            acc[packageName] = [];
+        const { pkgName } = cur;
+        if (!acc[pkgName]) {
+            acc[pkgName] = [];
         }
-        acc[packageName].push(cur);
+        acc[pkgName].push(cur);
         return acc;
     }, {});
-    const choices = Object.entries(reduced).map(([packageName, issues]) => {
+    const choices = Object.entries(reduced).map(([pkgName, issues]) => {
         const severity = getBatchSeverityString(issues);
         const version = getBatchVersionString(issues);
-        return `${severity} - ${packageName} ${version}`;
+        return `${severity} - ${pkgName} ${version}`;
     });
 
     const { selected } = await prompt({
@@ -48,11 +49,11 @@ const getBatchProps = async (issues) => {
     });
 
     const trimmed = selected.slice(SEVERITY_PREFIX_PADDING + ' - '.length); // remove the severity prefix
-    const packageName = trimmed.substring(0, trimmed.indexOf(' '));
+    const pkgName = trimmed.substring(0, trimmed.indexOf(' '));
     const version = trimmed.substring(trimmed.indexOf(' ') + 1);
-    const _issues = issues.filter((issue) => issue.package === packageName);
+    const _issues = issues.filter((issue) => issue.pkgName === pkgName);
     return {
-        packageName,
+        pkgName,
         version,
         issues: _issues,
     };
@@ -60,7 +61,7 @@ const getBatchProps = async (issues) => {
 
 const getBatchSeverityString = (issues) => {
     // assume that the issues are already sorted in descending order of priority score
-    const severity = capitalize(issues[0].severity[0]); // only use the severity level of the highest-scored issue
+    const severity = capitalize(issues[0].issueData.severity[0]); // only use the severity level of the highest-scored issue
     const score = issues[0].priorityScore; // only use the priority score of the highest-scored issue
     const severityText = `${severity}|${score}`;
     const padding = ' '
@@ -69,27 +70,24 @@ const getBatchSeverityString = (issues) => {
     return `${severityText}${padding}`;
 };
 
-const getBatchVersionString = (issues) => {
-    const versions = uniq(issues.map((x) => x.version)).sort(compare.versions);
-    return versions.join('/');
-};
+const getBatchVersionString = (issues) =>
+    uniq(flatten(issues.map((x) => x.pkgVersions))).sort(compare.versions).join('/');
 
-const getProjects = (issues) => {
-    return uniq(flatten(issues.map((issue) => issue.projects)));
-};
+const getProjects = (issues) =>
+    uniq(flatten(issues.map((issue) => issue.projects)));
 
 const getBatchIssue = async (issues) => {
     const sevMap = issues.reduce((acc, cur) => {
-        acc[cur.severity] = (acc[cur.severity] || []).concat(cur);
+        acc[cur.issueData.severity] = (acc[cur.issueData.severity] || []).concat(cur);
         return acc;
     }, {});
     const batchProps = await getBatchProps(issues);
 
     // if there is a single vulnerability, just use that for the description
-    let description = `${issues[0].title}`;
+    let description = `${issues[0].issueData.title}`;
     if (issues.length > 1) {
         // otherwise, if there are multiple vulnerabilities:
-        const titles = uniq(issues.map((x) => x.title));
+        const titles = uniq(issues.map((x) => x.issueData.title));
         const vuln = titles.length === 1 ? ` ${titles[0]}` : '';
         // if there are multiple of vulnerabilities of a single type, include the type in the description
         // otherwise, if there are multiple types of vulnerabilities of a multiple types, leave that out of the description
@@ -98,7 +96,7 @@ const getBatchIssue = async (issues) => {
     const projects = getProjects(issues);
     const showFullManifest = getUniqueProjectNamePrefixes(projects).size > 1;
     const title = `${getProjectName(projects)} - ${description} in ${
-        batchProps.packageName
+        batchProps.pkgName
     } ${batchProps.version}`;
 
     const headerText = `This issue has been created automatically by a source code scanner.\r\n\r\nSnyk project(s):`;
@@ -115,9 +113,12 @@ const getBatchIssue = async (issues) => {
                 .map(
                     (issue, i) =>
                         `\r\n\r\n<details>
-<summary>${i + 1}. ${issue.title} in ${issue.package} ${issue.version} (${
+<summary>${i + 1}. ${issue.issueData.title} in ${issue.pkgName} ${issue.pkgVersions.join('/')} (${
                             issue.id
                         })</summary>
+
+## Detailed paths
+${getGraph(issue, '* ', showFullManifest)}
 
 ${issue.description}
 - [${issue.id}](${issue.url})

--- a/cli/index.js
+++ b/cli/index.js
@@ -155,7 +155,7 @@ async function createIssues() {
         process.exit(0);
     }
 
-    // Combine duplicate issues across different projects into a single issue with an array of it's `projects` and an array of paths grouped by project (calld `from`)
+    // Combine duplicate issues across different projects into a single issue with an array of its `projects` and an array of paths grouped by project (called `from`)
     const reduced = issues.reduce((acc, cur) => {
         const { id, paths, project } = cur;
         if (!acc[id]) {

--- a/cli/index.js
+++ b/cli/index.js
@@ -110,7 +110,7 @@ async function createIssues() {
 
             // Populate each issue with all dependency paths by crawling the API links
             while (page !== null) {
-                const result = await snyk.get(page);
+                const result = await snyk.getLink(page);
                 // result.paths example:
                 // [
                 //     [

--- a/cli/labels.js
+++ b/cli/labels.js
@@ -34,7 +34,7 @@ const getLabels = (issueOrIssues) => {
     let labels = [...conf.ghLabels];
     labels.push('snyk');
     if (conf.severityLabel) {
-        const issues = Array.isArray(issueOrIssues) ? issueOrIssues : [];
+        const issues = Array.isArray(issueOrIssues) ? issueOrIssues : [issueOrIssues];
         const severities = uniq(issues.map((x) => `severity:${x.issueData.severity}`));
         labels = labels.concat(severities);
     }

--- a/cli/labels.js
+++ b/cli/labels.js
@@ -35,7 +35,7 @@ const getLabels = (issueOrIssues) => {
     labels.push('snyk');
     if (conf.severityLabel) {
         const issues = Array.isArray(issueOrIssues) ? issueOrIssues : [];
-        const severities = uniq(issues.map((x) => `severity:${x.severity}`));
+        const severities = uniq(issues.map((x) => `severity:${x.issueData.severity}`));
         labels = labels.concat(severities);
     }
     return labels;

--- a/cli/snyk.js
+++ b/cli/snyk.js
@@ -67,6 +67,17 @@ module.exports = class Snyk {
             })
         ).issues;
     }
+
+    async get(url) {
+        return (
+            await request({
+                method: 'get',
+                url,
+                headers: this._headers,
+                json: true,
+            })
+        );
+    }
 };
 
 function getSeverities(minimumSeverity) {

--- a/cli/snyk.js
+++ b/cli/snyk.js
@@ -56,6 +56,7 @@ module.exports = class Snyk {
                 url: `${baseUrl}/org/${this._orgId}/project/${projectId}/aggregated-issues`,
                 headers: this._headers,
                 body: {
+                    includeDescription: true,
                     filters: {
                         severities: getSeverities(this._minimumSeverity),
                         types: ['vuln'],

--- a/cli/snyk.js
+++ b/cli/snyk.js
@@ -53,7 +53,7 @@ module.exports = class Snyk {
         return (
             await request({
                 method: 'post',
-                url: `${baseUrl}/org/${this._orgId}/project/${projectId}/issues`,
+                url: `${baseUrl}/org/${this._orgId}/project/${projectId}/aggregated-issues`,
                 headers: this._headers,
                 body: {
                     filters: {

--- a/cli/snyk.js
+++ b/cli/snyk.js
@@ -69,7 +69,7 @@ module.exports = class Snyk {
         ).issues;
     }
 
-    async get(url) {
+    async getLink(url) {
         return (
             await request({
                 method: 'get',

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -67,37 +67,6 @@ const getManifestName = (project, showManifestPrefix) => {
 const getUniqueProjectNamePrefixes = (projects) =>
     new Set(projects.map(({ name }) => name.substring(0, name.indexOf(':'))));
 
-const getGraph = (issue, prefix, showFullManifest) => {
-    const uniqueProjectNamePrefixes = getUniqueProjectNamePrefixes(
-        issue.from.map(({ project }) => project)
-    );
-    const isMultipleBranches = uniqueProjectNamePrefixes.size > 1;
-    const pathsMap = issue.from.reduce((acc, { project, paths }) => {
-        const root = getManifestName(
-            project,
-            isMultipleBranches || showFullManifest
-        );
-        let path;
-        if (issue.from.length > 20 && paths.length > 1) {
-            // If there are lots of paths, reduce those that are transitive dependencies
-            path = `${paths[0]} > ... > ${paths[paths.length - 1]}`;
-        } else {
-            path = paths.join(' > ');
-        }
-        const key = `${prefix}${root} > ${path}`;
-        const val = acc.get(key);
-        if (val) {
-            acc.set(key, val + 1);
-        } else {
-            acc.set(key, 1);
-        }
-        return acc;
-    }, new Map());
-    return Array.from(pathsMap.entries())
-        .map(([k, v]) => (v === 1 ? k : k.replace('...', `... (x${v})`)))
-        .join('\r\n');
-};
-
 module.exports = {
     capitalize,
     compare: {
@@ -109,5 +78,4 @@ module.exports = {
     uniq,
     getProjectName,
     getUniqueProjectNamePrefixes,
-    getGraph,
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "enquirer": "^2.3.6",
         "lodash.flatten": "^4.4.0",
         "minimist": "^1.2.5",
+        "ora": "^5.4.1",
         "request": "^2.88.2",
         "request-promise-native": "^1.0.9",
         "semver": "^7.3.2"

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,265 @@
+'use strict';
+
+const test = require('tape');
+
+const { conf } = require('../cli/config');
+const { capitalize, compare, uniq, getProjectName, getUniqueProjectNamePrefixes, getGraph } = require('../cli/utils');
+
+test('compare.text', (t) => {
+    t.equal(compare.text('aaa', 'aaa'), 0);
+    t.equal(compare.text('aaa', 'AAA'), 0);
+    t.equal(compare.text('aaa', 'bbb'), -1);
+    t.equal(compare.text('bbb', 'aaa'), 1);
+    t.end();
+});
+
+test('compare.arrays', (t) => {
+    t.equal(compare.arrays(['aaa'], ['aaa']), compare.text('aaa', 'aaa'));
+    t.equal(compare.arrays(['aaa'], ['AAA']), compare.text('aaa', 'AAA'));
+    t.equal(compare.arrays(['aaa'], ['bbb']), compare.text('aaa', 'bbb'));
+    t.equal(compare.arrays(['bbb'], ['aaa']), compare.text('bbb', 'aaa'));
+
+    t.equal(compare.arrays(['a', 'b', 'c'], ['a', 'b', 'c']), compare.text('abc', 'abc'));
+    t.equal(compare.arrays(['c', 'b', 'a'], ['a', 'b', 'c']), compare.text('cba', 'abc'));
+    t.equal(compare.arrays(['a', 'b', 'c'], ['c', 'b', 'a']), compare.text('abc', 'cba'));
+
+    t.end();
+});
+
+test('compare.severities', (t) => {
+    t.equal(compare.severities('critical', 'critical'), 0);
+    t.equal(compare.severities('critical', 'high'), -1);
+    t.equal(compare.severities('critical', 'medium'), -1);
+    t.equal(compare.severities('critical', 'low'), -1);
+
+    t.equal(compare.severities('high', 'critical'), 1);
+    t.equal(compare.severities('high', 'high'), 0);
+    t.equal(compare.severities('high', 'medium'), -1);
+    t.equal(compare.severities('high', 'low'), -1);
+
+    t.equal(compare.severities('medium', 'critical'), 1);
+    t.equal(compare.severities('medium', 'high'), 1);
+    t.equal(compare.severities('medium', 'medium'), 0);
+    t.equal(compare.severities('medium', 'low'), -1);
+
+    t.equal(compare.severities('low', 'critical'), 1);
+    t.equal(compare.severities('low', 'high'), 1);
+    t.equal(compare.severities('low', 'medium'), 1);
+    t.equal(compare.severities('low', 'low'), 0);
+
+    t.end();
+});
+
+test('compare.versions', (t) => {
+    t.equal(compare.versions('1.2.3', '1.2.3'), 0);
+    t.equal(compare.versions('1.2.3', '1.2.4'), 1);
+    t.equal(compare.versions('1.2.4', '1.2.3'), -1);
+    t.end();
+});
+
+test('compare.versionArrays', (t) => {
+    t.equal(compare.versionArrays(['1.2.3'], ['1.2.3']), compare.versions('1.2.3', '1.2.3'));
+    t.equal(compare.versionArrays(['1.2.3'], ['1.2.4']), compare.versions('1.2.3', '1.2.4'));
+    t.equal(compare.versionArrays(['1.2.4'], ['1.2.3']), compare.versions('1.2.4', '1.2.3'));
+
+    t.equal(compare.versionArrays(['1.2.3', '2.0.0'], ['1.2.3']), compare.versions('2.0.0', '1.2.3'));
+    t.equal(compare.versionArrays(['2.0.0', '1.2.3'], ['1.2.3']), compare.versions('2.0.0', '1.2.3'));
+    t.equal(compare.versionArrays(['1.2.3'], ['1.2.3', '2.0.0']), compare.versions('1.2.3', '2.0.0'));
+    t.equal(compare.versionArrays(['1.2.3'], ['2.0.0', '1.2.3']), compare.versions('1.2.3', '2.0.0'));
+
+    t.end();
+});
+
+test('capitalize', (t) => {
+    t.test('non string', (t) => {
+        t.equal(capitalize(null), '');
+        t.equal(capitalize(undefined), '');
+        t.equal(capitalize(42), '');
+        t.equal(capitalize({}), '');
+        t.end();
+    });
+
+    t.test('string', (t) => {
+        t.equal(capitalize('peter pan'), 'Peter pan');
+        t.end();
+    });
+});
+
+test('uniq', (t) => {
+    t.deepEqual(uniq([]), []);
+    t.deepEqual(uniq([1, 2, 3, 2]), [1, 2, 3]);
+    t.deepEqual(uniq([{ foo: 1 }, { bar: 2 }, { baz: 3 }, { bar: 2 }]), [{ foo: 1 }, { bar: 2 }, { baz: 3 }, { bar: 2 }]);
+
+    const foo = { foo: 1 };
+    const bar = { bar: 2 };
+    const baz = { baz: 3 };
+    t.deepEqual(uniq([foo, bar, baz, bar]), [{ foo: 1 }, { bar: 2 }, { baz: 3 }]);
+
+    t.end();
+});
+
+test('getProjectName', (t) => {
+    t.equal(getProjectName({ name: 'foo' }), 'foo');
+    t.equal(getProjectName([{ name: 'foo' }]), 'foo');
+    t.equal(getProjectName([{ name: 'foo' }, { name: 'bar' }]), '2 projects');
+
+    conf.projectName = 'custom';
+    t.equal(getProjectName({ name: 'foo' }), 'custom');
+    t.equal(getProjectName([{ name: 'foo' }]), 'custom');
+    t.equal(getProjectName([{ name: 'foo' }, { name: 'bar' }]), 'custom');
+    delete conf.projectName;
+
+    t.end();
+});
+
+test('getUniqueProjectNamePrefixes', (t) => {
+    t.deepEqual(getUniqueProjectNamePrefixes([{ name: 'a:b' }, { name: 'c:d' }]), new Set(['a', 'c']));
+    t.end();
+});
+
+test('getGraph', (t) => {
+    t.test('with few paths', (t) => {
+        const issue = {
+            from: [
+                {
+                    project: { name: 'elastic/kibana(6.8):package.json' },
+                    paths: [
+                        [{ name: 'angular', version: '1.6.9' }],
+                        [
+                            { name: 'angular-elastic', version: '2.5.0' },
+                            { name: 'angular', version: '1.6.9' }
+                        ]
+                    ]
+                },
+                {
+                    project: { name: 'elastic/kibana(6.8):x-pack/package.json' },
+                    paths: [
+                        [{ name: 'angular', version: '1.6.9' }]
+                    ]
+              }
+          ]
+        };
+        const prefix = ' * ';
+        const showFullManifest = false;
+
+        t.equal(
+            getGraph(issue, prefix, showFullManifest),
+            ' * elastic/kibana(6.8):package.json > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > angular-elastic@2.5.0 > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):x-pack/package.json > angular@1.6.9'
+        );
+
+        t.end();
+    });
+
+    t.test('with many paths with different direct dependencies', (t) => {
+        const issue = {
+            from: [
+                {
+                    project: { name: 'elastic/kibana(6.8):package.json' },
+                    paths: []
+                },
+                {
+                    project: { name: 'elastic/kibana(6.8):x-pack/package.json' },
+                    paths: [
+                        [{ name: 'angular', version: '1.6.9' }]
+                    ]
+              }
+          ]
+        };
+        const prefix = ' * ';
+        const showFullManifest = false;
+
+        for (let n = 0; n < 20; n++) {
+            const path = [];
+
+            // the first run we only want angular as a direct dependency
+            if (n > 0) {
+                // on the second run we want angular as a direct dependency of a direct dependency
+                path.push({ name: `direct-dependency${n}`, version: '1.0.0' });
+                for (let depth = 1; depth < n; depth++) {
+                    // on all subsequent runs with want transitive dependencies
+                    path.push({ name: `transitive-dependency${n}-${depth}`, version: '1.0.0' });
+                }
+            }
+
+            path.push({ name: 'angular', version: '1.6.9' });
+
+            issue.from[0].paths.push(path);
+        }
+
+        t.equal(
+            getGraph(issue, prefix, showFullManifest),
+            ' * elastic/kibana(6.8):package.json > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency1@1.0.0 > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency2@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency3@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency4@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency5@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency6@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency7@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency8@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency9@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency10@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency11@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency12@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency13@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency14@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency15@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency16@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency17@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency18@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency19@1.0.0 > ... > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):x-pack/package.json > angular@1.6.9'
+        );
+
+        t.end();
+    });
+
+    t.test('with many paths with same direct dependencies', (t) => {
+        const issue = {
+            from: [
+                {
+                    project: { name: 'elastic/kibana(6.8):package.json' },
+                    paths: []
+                },
+                {
+                    project: { name: 'elastic/kibana(6.8):x-pack/package.json' },
+                    paths: [
+                        [{ name: 'angular', version: '1.6.9' }]
+                    ]
+              }
+          ]
+        };
+        const prefix = ' * ';
+        const showFullManifest = false;
+
+        for (let n = 0; n < 20; n++) {
+            const path = [];
+
+            // the first run we only want angular as a direct dependency
+            if (n > 0) {
+                // on the second run we want angular as a direct dependency of a direct dependency
+                path.push({ name: `direct-dependency`, version: '1.0.0' });
+                for (let depth = 1; depth < n; depth++) {
+                    // on all subsequent runs with want transitive dependencies
+                    path.push({ name: `transitive-dependency${n}-${depth}`, version: '1.0.0' });
+                }
+            }
+
+            path.push({ name: 'angular', version: '1.6.9' });
+
+            issue.from[0].paths.push(path);
+        }
+
+        t.equal(
+            getGraph(issue, prefix, showFullManifest),
+            ' * elastic/kibana(6.8):package.json > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency@1.0.0 > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):package.json > direct-dependency@1.0.0 > ... (x18) > angular@1.6.9\r\n' +
+            ' * elastic/kibana(6.8):x-pack/package.json > angular@1.6.9'
+        );
+
+        t.end();
+    });
+});


### PR DESCRIPTION
This PR updates the tool to use the new "[List all Aggregated Issues](https://snyk.docs.apiary.io/#reference/projects/aggregated-project-issues/list-all-aggregated-issues)" API endpoint:

```
https://snyk.io/api/v1/org/<orgId>/project/<projectId>/aggregated-issues
```

The old API endpoint that we used previously has been removed and its documentation likewise, so unfortunately it's not possible to see how the old data structure received from the API used to look. The old API endpoint was:

```
https://snyk.io/api/v1/org/<orgId>/project/<projectId>/issues
```

Fixes #16

## Todo

- [x] Figure out how to deal with the new `pkgVersions` array
- [x] Re-add support for vulnerability paths