### PR TITLE
Fix config bug and optimize issue creation

### DIFF
--- a/cli/config.js
+++ b/cli/config.js
@@ -99,7 +99,7 @@ exports.init = async (args) => {
         }
     } else {
         snykOrg = getConfig('snykOrg');
-        snykProjects = getConfig('snykProjects');
+        snykProjects = getConfig('snykProjects') || [];
     }
 
     Object.assign(


### PR DESCRIPTION
Resolves #21
Resolves #22

* Fixes error related to snykProjects variable when using `snyk-github-issue-creator` on a new machine that doesn't have a local `configstore` already
* Adds prompt to continue creating new issues

Example prompt:

```
✔ Pick a vulnerable package · H|696  - parse-link-header 1.0.1
Found 1 vulnerabilities...
Format: [Severity]|[Priority score] - [Package name] [Package Version] - [Vuln title] - [Vuln ID]

1. H|999 - bar 1.0.1 - Regular Expression Denial of Service (ReDoS) - SNYK-JS-...
 * projectname > foo > bar@1.0.1

✔ Add "1. H|999 - bar 1.0.1 - Regular Expression Denial of Service (ReDoS) - SNYK-JS-..." to batch? (y/N) · true
The following GitHub issues were created:
- "projectname - Regular Expression Denial of Service (ReDoS) in bar 1.0.1" https://github.com/orgname/reponame/issues/1234
? Pick another issue? (y/N) › false
```

By default, the prompt response is "N", but if you pick "Y" it takes you back to the issue list and allows you to pick another.