### PR TITLE
Fixes 'ensureLabelsAreCreated' by paginating API results

### DIFF
--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -42,7 +42,7 @@ module.exports = {
     let ghUpdatedIssues = []
 
     if (issues.length > 0) {
-      await ensureLabelsAreCreated(this.client, conf.ghOwner, conf.ghRepo, issues)
+      await ensureLabelsAreCreated(octokit, this.client, conf.ghOwner, conf.ghRepo, issues)
 
       if (conf.batch) {
         ghNewIssues = [await this.createIssue({

--- a/lib/github/labels.js
+++ b/lib/github/labels.js
@@ -50,14 +50,15 @@ const getLabelAttributes = (name) => {
 
 const ensureLabelsAreCreated = async (octokit, client, ghOwner, ghRepo, issues) => {
   const labels = getLabels(issues)
-  const response = await octokit.paginate(
+  const responseData = await octokit.paginate(
     await client.issues.listLabelsForRepo({
       owner: ghOwner,
       repo: ghRepo,
       per_page: 100
-    })
+    }),
+    (response) => response.data
   )
-  const currentLabels = response.map((x) => x.name)
+  const currentLabels = responseData.map((x) => x.name)
   const labelsToCreate = labels.filter((x) => !currentLabels.includes(x))
   if (!labelsToCreate.length || conf.dryRun) {
     return

--- a/lib/github/labels.js
+++ b/lib/github/labels.js
@@ -48,14 +48,16 @@ const getLabelAttributes = (name) => {
   return { name, ...(LABELS[name] || DEFAULT_LABEL) }
 }
 
-const ensureLabelsAreCreated = async (client, ghOwner, ghRepo, issues) => {
+const ensureLabelsAreCreated = async (octokit, client, ghOwner, ghRepo, issues) => {
   const labels = getLabels(issues)
-  const response = await client.issues.listLabelsForRepo({
-    owner: ghOwner,
-    repo: ghRepo,
-    per_page: 100
-  })
-  const currentLabels = response.data.map((x) => x.name)
+  const response = await octokit.paginate(
+    await client.issues.listLabelsForRepo({
+      owner: ghOwner,
+      repo: ghRepo,
+      per_page: 100
+    })
+  )
+  const currentLabels = response.map((x) => x.name)
   const labelsToCreate = labels.filter((x) => !currentLabels.includes(x))
   if (!labelsToCreate.length || conf.dryRun) {
     return

--- a/lib/snyk.js
+++ b/lib/snyk.js
@@ -2,7 +2,7 @@
 
 const request = require('request-promise-native')
 
-const baseUrl = 'https://snyk.io/api/v1'
+const baseV1Url = 'https://snyk.io/api/v1'
 const baseRestUrl = 'https://api.snyk.io'
 
 module.exports = class Snyk {
@@ -22,7 +22,7 @@ module.exports = class Snyk {
   async orgs () {
     return (
       await request({
-        url: `${baseUrl}/orgs`,
+        url: `${baseV1Url}/orgs`,
         headers: this._headers,
         json: true
       })
@@ -32,12 +32,12 @@ module.exports = class Snyk {
   async projects (orgId, selectedProjects = []) {
     const organizationId = orgId || this._orgId
 
-    const response = await paginateResponseData(
+    const responseData = await paginateRestResponseData(
       `${baseRestUrl}/rest/orgs/${organizationId}/projects?version=2023-11-27&meta.latest_issue_counts=true&limit=20`,
       this._headers
     )
 
-    return response.map((project) => {
+    return responseData.map((project) => {
       const { critical, high, medium, low } = project.meta.latest_issue_counts
       const issueCountTotal = critical + high + medium + low
       return {
@@ -59,7 +59,7 @@ module.exports = class Snyk {
     return (
       await request({
         method: 'post',
-        url: `${baseUrl}/org/${this._orgId}/project/${projectId}/aggregated-issues`,
+        url: `${baseV1Url}/org/${this._orgId}/project/${projectId}/aggregated-issues`,
         headers: this._headers,
         body: {
           includeDescription: true,
@@ -98,7 +98,7 @@ function getSeverities (minimumSeverity) {
   return ['critical', 'high', 'medium', 'low']
 }
 
-async function paginateResponseData (url, headers, method = 'get') {
+async function paginateRestResponseData (url, headers, method = 'get') {
   const reponseData = []
   do {
     const response = await request({

--- a/lib/snyk.js
+++ b/lib/snyk.js
@@ -3,6 +3,7 @@
 const request = require('request-promise-native')
 
 const baseUrl = 'https://snyk.io/api/v1'
+const baseRestUrl = 'https://api.snyk.io'
 
 module.exports = class Snyk {
   constructor ({ token, orgId, minimumSeverity }) {
@@ -28,25 +29,32 @@ module.exports = class Snyk {
     ).orgs
   }
 
-  async projects (orgId, selectedProjects = []) {
-    const { projects } = await request({
-      url: `${baseUrl}/org/${orgId || this._orgId}/projects`,
-      headers: this._headers,
-      json: true
+  async projects(orgId, selectedProjects = []) {
+    const organizationId = orgId || this._orgId
+
+    const response = await paginateResponseData(
+      `${baseRestUrl}/rest/orgs/${organizationId}/projects?version=2023-11-27&meta.latest_issue_counts=true&limit=20`,
+      this._headers
+    )
+
+    return response.map((project) => {
+      const { latest_issue_counts } = project.meta
+      const { critical, high, medium, low } = latest_issue_counts
+      const issueCountTotal = critical + high + medium + low
+      return {
+        id: project.id,
+        name: project.attributes.name,
+        isMonitored:
+          project.attributes.status === "active",
+        issueCountTotal
+      }
     })
-    return projects
-      .map((project) => {
-        const { issueCountsBySeverity } = project
-        const { critical, high, medium, low } = issueCountsBySeverity
-        const issueCountTotal = critical + high + medium + low
-        return { ...project, issueCountTotal }
-      })
-      .filter(({ id, isMonitored, issueCountTotal }) => {
-        if (selectedProjects.includes(id)) {
-          return true
-        }
-        return isMonitored
-      })
+    .filter(({ id, isMonitored, issueCountTotal }) => {
+      if (selectedProjects.includes(id)) {
+        return true
+      }
+      return isMonitored
+    })
   }
 
   async issues (projectId) {
@@ -90,4 +98,21 @@ function getSeverities (minimumSeverity) {
     return ['critical', 'high', 'medium']
   }
   return ['critical', 'high', 'medium', 'low']
+}
+
+async function paginateResponseData(url, headers, method = 'get') {
+  const reponseData = []
+  do {
+    let response = await request({
+        method,
+        url,
+        headers,
+        json: true
+    })
+    reponseData.push(...response.data)
+    if (response.links.next) url = baseRestUrl + response.links.next
+    else url = undefined
+  } while (url)
+
+  return reponseData
 }

--- a/lib/snyk.js
+++ b/lib/snyk.js
@@ -29,7 +29,7 @@ module.exports = class Snyk {
     ).orgs
   }
 
-  async projects(orgId, selectedProjects = []) {
+  async projects (orgId, selectedProjects = []) {
     const organizationId = orgId || this._orgId
 
     const response = await paginateResponseData(
@@ -38,18 +38,16 @@ module.exports = class Snyk {
     )
 
     return response.map((project) => {
-      const { latest_issue_counts } = project.meta
-      const { critical, high, medium, low } = latest_issue_counts
+      const { critical, high, medium, low } = project.meta.latest_issue_counts
       const issueCountTotal = critical + high + medium + low
       return {
         id: project.id,
         name: project.attributes.name,
         isMonitored:
-          project.attributes.status === "active",
+          project.attributes.status === 'active',
         issueCountTotal
       }
-    })
-    .filter(({ id, isMonitored, issueCountTotal }) => {
+    }).filter(({ id, isMonitored, issueCountTotal }) => {
       if (selectedProjects.includes(id)) {
         return true
       }
@@ -100,14 +98,14 @@ function getSeverities (minimumSeverity) {
   return ['critical', 'high', 'medium', 'low']
 }
 
-async function paginateResponseData(url, headers, method = 'get') {
+async function paginateResponseData (url, headers, method = 'get') {
   const reponseData = []
   do {
-    let response = await request({
-        method,
-        url,
-        headers,
-        json: true
+    const response = await request({
+      method,
+      url,
+      headers,
+      json: true
     })
     reponseData.push(...response.data)
     if (response.links.next) url = baseRestUrl + response.links.next

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@elastic/snyk-github-issue-creator",
-    "version": "2.1.2",
+    "version": "2.1.1",
     "description": "A CLI for creating GitHub issues based on vulnerabilities from your Snyk projects",
     "main": "lib/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@elastic/snyk-github-issue-creator",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "description": "A CLI for creating GitHub issues based on vulnerabilities from your Snyk projects",
     "main": "lib/index.js",
     "scripts": {


### PR DESCRIPTION
We have > 100 labels in the security repo, and we were not paginating the call to retrieve them. Previously, this was working because the labels we wanted to apply to an issue (typically `Kibana`, `snyk`, and `triage_needed`) were within the first 100 results, but as new labels were created, some of the labels are now in the second page of results (specifically "triage_needed"). This caused `ensureLabelsAreCreated` to throw when attempting to create an existing label.

This PR adds pagination of the `listLabelsForRepo` API call.

Additionally, this PR replaces the deprecated snyk List all projects v1 API with the newer REST API. The v1 API EOL is December 22, 2023. See the [official statement](https://headwayapp.co/snyk-io-updates/snyk-tools-which-use-the-list-all-projects-v1-api-now-use-rest-apis-271874) for more information.