### PR TITLE
Fixes issue description and octokit pagination

### DIFF
--- a/lib/github/batch.js
+++ b/lib/github/batch.js
@@ -35,8 +35,8 @@ module.exports = async (issues) => {
   const headerText = 'This issue has been created automatically by [snyk-github-issue-creator](https://github.com/elastic/snyk-github-issue-creator).\r\n\r\nSnyk project(s):'
   const projectText = projects
     .map(
-      ({ name, browseUrl }) =>
-                `\r\n * [\`${name}\`](${browseUrl})`
+      ({ name, browseUrl, imageTag }) =>
+                `\r\n * [\`${name}\`](${browseUrl}) (manifest version ${imageTag})`
     )
     .join('')
   const sectionText = Object.keys(sevMap)

--- a/lib/github/batch.js
+++ b/lib/github/batch.js
@@ -35,8 +35,8 @@ module.exports = async (issues) => {
   const headerText = 'This issue has been created automatically by [snyk-github-issue-creator](https://github.com/elastic/snyk-github-issue-creator).\r\n\r\nSnyk project(s):'
   const projectText = projects
     .map(
-      ({ name, browseUrl, imageTag }) =>
-                `\r\n * [\`${name}\`](${browseUrl}) (manifest version ${imageTag})`
+      ({ name, browseUrl }) =>
+                `\r\n * [\`${name}\`](${browseUrl})`
     )
     .join('')
   const sectionText = Object.keys(sevMap)

--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -33,7 +33,7 @@ module.exports = {
           ])
       )
     } catch (err) {
-      throw new Error(dressError(err, `Failed to paginate octakit request for existing issues in repository ${conf.ghRepo}`))
+      throw new Error(dressError(err, `Failed to paginate octokit request for existing issues in repository ${conf.ghRepo}`))
     }
   },
 

--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -21,7 +21,7 @@ module.exports = {
   },
 
   // retrieve issue IDs already created in GitHub
-  async existingIssues() {
+  async existingIssues () {
     try {
       return await octokit.paginate(
         `GET /search/issues?q=repo%3A${conf.ghOwner}/${conf.ghRepo}+is%3Aissue+label%3Asnyk`,
@@ -31,8 +31,7 @@ module.exports = {
             existingIssue.number
           ])
       )
-    }
-    catch (err) {
+    } catch (err) {
       throw new Error(`Failed to paginate octakit request for existing issues in repository ${conf.ghRepo}, error: ${err.message}`, { cause: err })
     }
   },
@@ -41,9 +40,8 @@ module.exports = {
     if (conf.dryRun) return
     try {
       return await this.client.issues.create(options)
-    }
-    catch (err) {
-      throw new Error(`Failed to ${options.issue_number?'update':'create'} issue: ${options.issue_number?options.issue_number:options.title}, error: ${err.message}`, { cause: err })
+    } catch (err) {
+      throw new Error(`Failed to ${options.issue_number ? 'update' : 'create'} issue: ${options.issue_number ? options.issue_number : options.title}, error: ${err.message}`, { cause: err })
     }
   },
 

--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -21,20 +21,30 @@ module.exports = {
   },
 
   // retrieve issue IDs already created in GitHub
-  async existingIssues () {
-    return await octokit.paginate(
-            `GET /search/issues?q=repo%3A${conf.ghOwner}/${conf.ghRepo}+is%3Aissue+label%3Asnyk`,
-            (response) =>
-              response.data.map((existingIssue) => [
-                existingIssue.title,
-                existingIssue.number
-              ])
-    )
+  async existingIssues() {
+    try {
+      return await octokit.paginate(
+        `GET /search/issues?q=repo%3A${conf.ghOwner}/${conf.ghRepo}+is%3Aissue+label%3Asnyk`,
+        (response) =>
+          response.data.map((existingIssue) => [
+            existingIssue.title,
+            existingIssue.number
+          ])
+      )
+    }
+    catch (err) {
+      throw new Error(`Failed to paginate octakit request for existing issues in repository ${conf.ghRepo}, error: ${err.message}`, { cause: err })
+    }
   },
 
   async createIssue (options) {
     if (conf.dryRun) return
-    return await this.client.issues.create(options)
+    try {
+      return await this.client.issues.create(options)
+    }
+    catch (err) {
+      throw new Error(`Failed to ${options.issue_number?'update':'create'} issue: ${options.issue_number?options.issue_number:options.title}, error: ${err.message}`, { cause: err })
+    }
   },
 
   async createIssues (issues, existingIssues) {

--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -7,6 +7,7 @@ const chalk = require('chalk')
 const getBatchIssue = require('./batch')
 const { conf } = require('../config')
 const { getProjectName, getGraph } = require('./utils')
+const { dressError } = require('../utils')
 
 const { getLabels, ensureLabelsAreCreated } = require('./labels')
 
@@ -32,7 +33,7 @@ module.exports = {
           ])
       )
     } catch (err) {
-      throw new Error(`Failed to paginate octakit request for existing issues in repository ${conf.ghRepo}, error: ${err.message}`, { cause: err })
+      throw new Error(dressError(err, `Failed to paginate octakit request for existing issues in repository ${conf.ghRepo}`))
     }
   },
 
@@ -41,7 +42,7 @@ module.exports = {
     try {
       return await this.client.issues.create(options)
     } catch (err) {
-      throw new Error(`Failed to ${options.issue_number ? 'update' : 'create'} issue: ${options.issue_number ? options.issue_number : options.title}, error: ${err.message}`, { cause: err })
+      throw new Error(dressError(err, `Failed to ${options.issue_number ? 'update' : 'create'} issue: ${options.issue_number ? options.issue_number : options.title}`))
     }
   },
 

--- a/lib/github/labels.js
+++ b/lib/github/labels.js
@@ -61,8 +61,7 @@ const ensureLabelsAreCreated = async (octokit, client, ghOwner, ghRepo, issues) 
       }),
       (response) => response.data
     )
-  }
-  catch (err) {
+  } catch (err) {
     throw new Error(`Failed to paginate octakit request for labels in repository ${ghRepo}, error: ${err.message}`, { cause: err })
   }
 
@@ -75,7 +74,7 @@ const ensureLabelsAreCreated = async (octokit, client, ghOwner, ghRepo, issues) 
   await Promise.all(
     labelsToCreate.map((name) => {
       try {
-        client.issues
+        return client.issues
           .createLabel({
             owner: ghOwner,
             repo: ghRepo,
@@ -84,8 +83,7 @@ const ensureLabelsAreCreated = async (octokit, client, ghOwner, ghRepo, issues) 
           .then(() => {
             console.log(`Created GitHub label: "${name}"`)
           })
-      }
-      catch (err) {
+      } catch (err) {
         throw new Error(`Failed to create GitHub label '${name}', error: ${err.message}`, { cause: err })
       }
     })

--- a/lib/github/labels.js
+++ b/lib/github/labels.js
@@ -53,16 +53,9 @@ const ensureLabelsAreCreated = async (octokit, client, ghOwner, ghRepo, issues) 
 
   let responseData
   try {
-    responseData = await octokit.paginate(
-      await client.issues.listLabelsForRepo({
-        owner: ghOwner,
-        repo: ghRepo,
-        per_page: 100
-      }),
-      (response) => response.data
-    )
+    responseData = await octokit.paginate(`GET /repos/${conf.ghOwner}/${conf.ghRepo}/labels`)
   } catch (err) {
-    throw new Error(dressError(err, `Failed to paginate octakit request for labels in repository: ${ghRepo}`))
+    throw new Error(dressError(err, `Failed to paginate octokit request for labels in repository: ${ghRepo}`))
   }
 
   const currentLabels = responseData.map((x) => x.name)

--- a/lib/github/labels.js
+++ b/lib/github/labels.js
@@ -53,7 +53,7 @@ const ensureLabelsAreCreated = async (octokit, client, ghOwner, ghRepo, issues) 
 
   let responseData
   try {
-    responseData = await octokit.paginate(`GET /repos/${conf.ghOwner}/${conf.ghRepo}/labels`)
+    responseData = await octokit.paginate(`GET /repos/${conf.ghOwner}/${conf.ghRepo}/labels?per_page=100`)
   } catch (err) {
     throw new Error(dressError(err, `Failed to paginate octokit request for labels in repository: ${ghRepo}`))
   }

--- a/lib/github/labels.js
+++ b/lib/github/labels.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { conf } = require('../config')
-const { uniq } = require('../utils')
+const { uniq, dressError } = require('../utils')
 
 const LABELS = {
   snyk: {
@@ -62,7 +62,7 @@ const ensureLabelsAreCreated = async (octokit, client, ghOwner, ghRepo, issues) 
       (response) => response.data
     )
   } catch (err) {
-    throw new Error(`Failed to paginate octakit request for labels in repository ${ghRepo}, error: ${err.message}`, { cause: err })
+    throw new Error(dressError(err, `Failed to paginate octakit request for labels in repository: ${ghRepo}`))
   }
 
   const currentLabels = responseData.map((x) => x.name)
@@ -84,7 +84,7 @@ const ensureLabelsAreCreated = async (octokit, client, ghOwner, ghRepo, issues) 
             console.log(`Created GitHub label: "${name}"`)
           })
       } catch (err) {
-        throw new Error(`Failed to create GitHub label '${name}', error: ${err.message}`, { cause: err })
+        throw new Error(dressError(err, `Failed to create GitHub label '${name}' in repository: ${ghRepo}`))
       }
     })
   )

--- a/lib/github/labels.js
+++ b/lib/github/labels.js
@@ -50,14 +50,22 @@ const getLabelAttributes = (name) => {
 
 const ensureLabelsAreCreated = async (octokit, client, ghOwner, ghRepo, issues) => {
   const labels = getLabels(issues)
-  const responseData = await octokit.paginate(
-    await client.issues.listLabelsForRepo({
-      owner: ghOwner,
-      repo: ghRepo,
-      per_page: 100
-    }),
-    (response) => response.data
-  )
+
+  let responseData
+  try {
+    responseData = await octokit.paginate(
+      await client.issues.listLabelsForRepo({
+        owner: ghOwner,
+        repo: ghRepo,
+        per_page: 100
+      }),
+      (response) => response.data
+    )
+  }
+  catch (err) {
+    throw new Error(`Failed to paginate octakit request for labels in repository ${ghRepo}, error: ${err.message}`, { cause: err })
+  }
+
   const currentLabels = responseData.map((x) => x.name)
   const labelsToCreate = labels.filter((x) => !currentLabels.includes(x))
   if (!labelsToCreate.length || conf.dryRun) {
@@ -65,17 +73,22 @@ const ensureLabelsAreCreated = async (octokit, client, ghOwner, ghRepo, issues) 
   }
 
   await Promise.all(
-    labelsToCreate.map((name) =>
-      client.issues
-        .createLabel({
-          owner: ghOwner,
-          repo: ghRepo,
-          ...getLabelAttributes(name)
-        })
-        .then(() => {
-          console.log(`Created GitHub label: "${name}"`)
-        })
-    )
+    labelsToCreate.map((name) => {
+      try {
+        client.issues
+          .createLabel({
+            owner: ghOwner,
+            repo: ghRepo,
+            ...getLabelAttributes(name)
+          })
+          .then(() => {
+            console.log(`Created GitHub label: "${name}"`)
+          })
+      }
+      catch (err) {
+        throw new Error(`Failed to create GitHub label '${name}', error: ${err.message}`, { cause: err })
+      }
+    })
   )
 }
 

--- a/lib/snyk.js
+++ b/lib/snyk.js
@@ -30,48 +30,47 @@ module.exports = class Snyk {
     ).orgs
   }
 
-  async queryOrgInfo (organizationId) {
+  async queryProjectDetails (organizationId, projectId) {
     try {
-      const response = await request({
+      return await request({
         method: 'get',
-        url: `${baseRestUrl}/orgs/${organizationId}?version=2023-11-27`,
+        url: `${baseV1Url}/org/${organizationId}/project/${projectId}`, // project snapshot via v1 POST org/:orgId/project/:projectId/history
         headers: this._headers,
         json: true
       })
-
-      if (response.data === undefined || response.data.attributes === undefined || response.data.attributes.name === undefined) {
-        throw new Error('expected response to include data.attributes.name')
-      }
-
-      return response.data
     } catch (err) {
-      throw new Error(dressError(err, `Failed to query snyk organization with id ${organizationId}`))
+      throw new Error(dressError(err, `Failed to query snyk project details. Organization ID: ${organizationId}, Project ID: ${projectId}`))
     }
   }
 
   async projects (orgId, selectedProjects = []) {
     const organizationId = orgId || this._orgId
 
-    const organization = await this.queryOrgInfo(organizationId)
-
     const responseData = await paginateRestResponseData(
       `${baseRestUrl}/orgs/${organizationId}/projects?version=2023-11-27&meta.latest_issue_counts=true&limit=20`,
       this._headers
     )
 
-    return responseData.map((project) => {
-      const { critical, high, medium, low } = project.meta.latest_issue_counts
-      const issueCountTotal = critical + high + medium + low
+    const projects = await Promise.all(
+      responseData.map(async (project) => {
+        const { critical, high, medium, low } = project.meta.latest_issue_counts
+        const issueCountTotal = critical + high + medium + low
 
-      return {
-        id: project.id,
-        name: project.attributes.name,
-        isMonitored:
-          project.attributes.status === 'active',
-        issueCountTotal,
-        browseUrl: `https://app.snyk.io/org/${organization.attributes.name.toLowerCase()}/project/${project.id}`
-      }
-    }).filter(({ id, isMonitored }) => {
+        const projectDetails = await this.queryProjectDetails(organizationId, project.id)
+
+        return {
+          id: project.id,
+          name: project.attributes.name,
+          isMonitored:
+            project.attributes.status === 'active',
+          issueCountTotal,
+          browseUrl: projectDetails.browseUrl,
+          imageTag: projectDetails.imageTag
+        }
+      })
+    )
+
+    return projects.filter(({ id, isMonitored }) => {
       if (selectedProjects.includes(id)) {
         return true
       }

--- a/lib/snyk.js
+++ b/lib/snyk.js
@@ -29,7 +29,7 @@ module.exports = class Snyk {
     ).orgs
   }
 
-  async queryOrgInfo(organizationId) {
+  async queryOrgInfo (organizationId) {
     try {
       const response = await request({
         method: 'get',
@@ -39,12 +39,11 @@ module.exports = class Snyk {
       })
 
       if (response.data === undefined || response.data.attributes === undefined || response.data.attributes.name === undefined) {
-        throw new Error (`expected response to include data.attributes.name`)
+        throw new Error('expected response to include data.attributes.name')
       }
 
       return response.data
-    }
-    catch (err) {
+    } catch (err) {
       throw new Error(`Failed to query snyk organization with id ${organizationId}, error: ${err.message}`, { cause: err })
     }
   }
@@ -69,7 +68,7 @@ module.exports = class Snyk {
         isMonitored:
           project.attributes.status === 'active',
         issueCountTotal,
-        browseUrl: `https://app.snyk.io/org/${organization.attributes.name.toLowerCase()}/project/${project.id}`,
+        browseUrl: `https://app.snyk.io/org/${organization.attributes.name.toLowerCase()}/project/${project.id}`
       }
     }).filter(({ id, isMonitored }) => {
       if (selectedProjects.includes(id)) {
@@ -122,7 +121,7 @@ function getSeverities (minimumSeverity) {
   return ['critical', 'high', 'medium', 'low']
 }
 
-async function paginateRestResponseData(url, headers, method = 'get') {
+async function paginateRestResponseData (url, headers, method = 'get') {
   try {
     const reponseData = []
     do {
@@ -133,13 +132,12 @@ async function paginateRestResponseData(url, headers, method = 'get') {
         json: true
       })
       reponseData.push(...response.data)
-      if (response.links.next) url = baseRestUrl + response.links.next / trimStart('/rest')
+      if (response.links.next) url = baseRestUrl + response.links.next.trimStart('/rest')
       else url = undefined
     } while (url)
 
     return reponseData
-  }
-  catch (err) {
+  } catch (err) {
     throw new Error(`Failed to paginate request for ${method} ${url}, error: ${err.message}`, { cause: err })
   }
 }

--- a/lib/snyk.js
+++ b/lib/snyk.js
@@ -34,7 +34,7 @@ module.exports = class Snyk {
     try {
       return await request({
         method: 'get',
-        url: `${baseV1Url}/org/${organizationId}/project/${projectId}`, // project snapshot via v1 POST org/:orgId/project/:projectId/history
+        url: `${baseV1Url}/org/${organizationId}/project/${projectId}`,
         headers: this._headers,
         json: true
       })

--- a/lib/snyk.js
+++ b/lib/snyk.js
@@ -3,7 +3,7 @@
 const request = require('request-promise-native')
 
 const baseV1Url = 'https://snyk.io/api/v1'
-const baseRestUrl = 'https://api.snyk.io'
+const baseRestUrl = 'https://api.snyk.io/rest'
 
 module.exports = class Snyk {
   constructor ({ token, orgId, minimumSeverity }) {
@@ -29,25 +29,49 @@ module.exports = class Snyk {
     ).orgs
   }
 
+  async queryOrgInfo(organizationId) {
+    try {
+      const response = await request({
+        method: 'get',
+        url: `${baseRestUrl}/orgs/${organizationId}?version=2023-11-27`,
+        headers: this._headers,
+        json: true
+      })
+
+      if (response.data === undefined || response.data.attributes === undefined || response.data.attributes.name === undefined) {
+        throw new Error (`expected response to include data.attributes.name`)
+      }
+
+      return response.data
+    }
+    catch (err) {
+      throw new Error(`Failed to query snyk organization with id ${organizationId}, error: ${err.message}`, { cause: err })
+    }
+  }
+
   async projects (orgId, selectedProjects = []) {
     const organizationId = orgId || this._orgId
 
+    const organization = await this.queryOrgInfo(organizationId)
+
     const responseData = await paginateRestResponseData(
-      `${baseRestUrl}/rest/orgs/${organizationId}/projects?version=2023-11-27&meta.latest_issue_counts=true&limit=20`,
+      `${baseRestUrl}/orgs/${organizationId}/projects?version=2023-11-27&meta.latest_issue_counts=true&limit=20`,
       this._headers
     )
 
     return responseData.map((project) => {
       const { critical, high, medium, low } = project.meta.latest_issue_counts
       const issueCountTotal = critical + high + medium + low
+
       return {
         id: project.id,
         name: project.attributes.name,
         isMonitored:
           project.attributes.status === 'active',
-        issueCountTotal
+        issueCountTotal,
+        browseUrl: `https://app.snyk.io/org/${organization.attributes.name.toLowerCase()}/project/${project.id}`,
       }
-    }).filter(({ id, isMonitored, issueCountTotal }) => {
+    }).filter(({ id, isMonitored }) => {
       if (selectedProjects.includes(id)) {
         return true
       }
@@ -98,19 +122,24 @@ function getSeverities (minimumSeverity) {
   return ['critical', 'high', 'medium', 'low']
 }
 
-async function paginateRestResponseData (url, headers, method = 'get') {
-  const reponseData = []
-  do {
-    const response = await request({
-      method,
-      url,
-      headers,
-      json: true
-    })
-    reponseData.push(...response.data)
-    if (response.links.next) url = baseRestUrl + response.links.next
-    else url = undefined
-  } while (url)
+async function paginateRestResponseData(url, headers, method = 'get') {
+  try {
+    const reponseData = []
+    do {
+      const response = await request({
+        method,
+        url,
+        headers,
+        json: true
+      })
+      reponseData.push(...response.data)
+      if (response.links.next) url = baseRestUrl + response.links.next / trimStart('/rest')
+      else url = undefined
+    } while (url)
 
-  return reponseData
+    return reponseData
+  }
+  catch (err) {
+    throw new Error(`Failed to paginate request for ${method} ${url}, error: ${err.message}`, { cause: err })
+  }
 }

--- a/lib/snyk.js
+++ b/lib/snyk.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const request = require('request-promise-native')
+const { dressError } = require('./utils')
 
 const baseV1Url = 'https://snyk.io/api/v1'
 const baseRestUrl = 'https://api.snyk.io/rest'
@@ -44,7 +45,7 @@ module.exports = class Snyk {
 
       return response.data
     } catch (err) {
-      throw new Error(`Failed to query snyk organization with id ${organizationId}, error: ${err.message}`, { cause: err })
+      throw new Error(dressError(err, `Failed to query snyk organization with id ${organizationId}`))
     }
   }
 
@@ -138,6 +139,6 @@ async function paginateRestResponseData (url, headers, method = 'get') {
 
     return reponseData
   } catch (err) {
-    throw new Error(`Failed to paginate request for ${method} ${url}, error: ${err.message}`, { cause: err })
+    throw new Error(dressError(err, `Failed to paginate request for ${method} ${url}`))
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -73,6 +73,10 @@ const capitalize = (s) => {
 
 const uniq = (array) => [...new Set(array)]
 
+const dressError = (err, msg) => {
+  return `${msg}, error: ${err.status ? err.status + ' - ' : ''}${err.message}, response: ${err.response}`
+}
+
 module.exports = {
   capitalize,
   compare: {
@@ -82,5 +86,6 @@ module.exports = {
     versionArrays: compareVersionArrays,
     arrays: compareArrays
   },
-  uniq
+  uniq,
+  dressError
 }


### PR DESCRIPTION
Closes #27 
Closes #29 

## Summary 
This PR resolves the issue of undefined project links manifest version (see https://github.com/elastic/snyk-github-issue-creator/issues/27), as well as the issue where `octokit` pagination with API calls caused improper headers in low-level fetch in node >= 18 (see https://github.com/elastic/snyk-github-issue-creator/issues/29)

### Details

#### Undefined Values
The project links were derived from the response of the deprecated v1 all projects API - each project body contained a `browseUrl` property. According to the API migration documentation it:

> can be constructed using organization ID and project ID https://app.snyk.io/org/:orgId/project/:projectId

But this is inaccurate. The URL can be constructed from the organization name in lower-case and the project ID as such: `https://app.snyk.io/org/[org name]/project/[projectId]`

The manifest version used to be populated from the `imageTag` property return from the deprecated v1 all projects API. The API migration documentation claims that it:

> Can be fetched from the latest project snapshot via v1 POST org/:orgId/project/:projectId/history

But I found that this did not work. Example for several projects:

> *** PROJECT IMAGE TAG: undefined
> *** PROJECT IMAGE TAG: undefined
> *** PROJECT IMAGE TAG: undefined
> *** PROJECT IMAGE TAG: 20.10.0-slim
> *** PROJECT IMAGE TAG: undefined
> *** PROJECT IMAGE TAG: 20.10.0-slim
> *** PROJECT IMAGE TAG: undefined
> *** PROJECT IMAGE TAG: nonroot
> *** PROJECT IMAGE TAG: undefined
> *** PROJECT IMAGE TAG: undefined
> *** PROJECT IMAGE TAG: undefined
> *** PROJECT IMAGE TAG: undefined
> *** PROJECT IMAGE TAG: undefined
> *** PROJECT IMAGE TAG: undefined 

Originally, I removed the `manifest version` from the output issue description, as it is not included in our other issue-generation automations. However, I found that I could still properly query for `imageTag` with the non-deprecated v1 single project API. As this API also returns the `browseUrl` property, it is not necessary to query for the organization name and manually construct the URL.

#### Fetch Header Issue
This PR fixes the fetch header issue by replacing the `octokit` API call within the `octokit` pagination call for querying issue labels with a raw request URL. This seems to resolve this issue and executes correctly in node 16, 18, and 20.

#### Additional
Lastly, error reporting around requests has been improved throughout the codebase. Previously, only low-level exceptions were being displayed if something went wrong, which did not include a path or reference back to which high-level operation caused the error. Error reports will now include a better description, along with a response status code and response details if available. 