### PR TITLE
Fixes '/rest' duplication in pagination path

### DIFF
--- a/lib/snyk.js
+++ b/lib/snyk.js
@@ -132,7 +132,7 @@ async function paginateRestResponseData (url, headers, method = 'get') {
         json: true
       })
       reponseData.push(...response.data)
-      if (response.links.next) url = baseRestUrl + response.links.next.trimStart('/rest')
+      if (response.links.next) url = baseRestUrl + response.links.next.replace('/rest','')
       else url = undefined
     } while (url)
 

--- a/lib/snyk.js
+++ b/lib/snyk.js
@@ -132,7 +132,7 @@ async function paginateRestResponseData (url, headers, method = 'get') {
         json: true
       })
       reponseData.push(...response.data)
-      if (response.links.next) url = baseRestUrl + response.links.next.replace('/rest','')
+      if (response.links.next) url = baseRestUrl + response.links.next.replace('/rest', '')
       else url = undefined
     } while (url)
 


### PR DESCRIPTION
Closes #30 

Replaces `trimStart` with `replace` in order to de-duplicate '/rest' in pagination path.